### PR TITLE
Fix closing error in GUI

### DIFF
--- a/MotorLogger.py
+++ b/MotorLogger.py
@@ -414,7 +414,11 @@ class MotorLoggerGUI:
                 self._cap_thread.join(timeout=2)
             self.scope.disconnect()
         finally:
-            self.root.destroy()
+            if self.root.winfo_exists():
+                try:
+                    self.root.destroy()
+                except tk.TclError:
+                    pass
 
 # ─── Entry point ─────────────────────────────────────────────────────────────
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- avoid destroying Tk root twice

## Testing
- `python3 -m py_compile MotorLogger.py`

------
https://chatgpt.com/codex/tasks/task_e_685e8b4cbc508323886c343274ee5def