### PR TITLE
Add sample interval limit handling

### DIFF
--- a/MotorLogger.py
+++ b/MotorLogger.py
@@ -51,6 +51,13 @@ USE_SCOPE = True
 if USE_SCOPE:
     from pyx2cscope.x2cscope import X2CScope
 
+# ─── Sample interval limitations ----------------------------------------------
+# Each monitored variable introduces roughly 3 ms of communication overhead.
+# When ``ENFORCE_SAMPLE_LIMIT`` is ``True``, the GUI blocks sample intervals
+# shorter than ``MIN_DELAY_PER_VAR_MS * number_of_selected_vars``.
+ENFORCE_SAMPLE_LIMIT = True
+MIN_DELAY_PER_VAR_MS = 3  # ms added per variable during capture
+
 # ─── Variable paths we want to log ───────────────────────────────────────────
 VAR_PATHS = {
     "idqCmd_q":        "motor.idqCmd.q",
@@ -157,6 +164,7 @@ class MotorLoggerGUI:
         self.scale_entry  = _row("Scale (RPM/cnt):",  "0.19913", 1)
         self.dur_entry    = _row("Log time (s):",     "5",    2)
         self.sample_entry = _row("Sample every (ms):", str(self.DEFAULT_DT), 3)
+        ttk.Label(parms, text="≈3 ms per enabled variable").grid(row=3, column=2, sticky="w")
 
         # Buttons
         btn = ttk.Frame(main); btn.pack(pady=(6, 2))
@@ -272,6 +280,14 @@ class MotorLoggerGUI:
         if not self.selected_vars:
             messagebox.showwarning("Variables", "Select at least one variable")
             return
+        if ENFORCE_SAMPLE_LIMIT:
+            min_dt = MIN_DELAY_PER_VAR_MS * len(self.selected_vars)
+            if dt_ms < min_dt:
+                messagebox.showwarning(
+                    "Sample interval",
+                    f"Minimum allowed interval is {min_dt:.0f} ms for {len(self.selected_vars)} vars",
+                )
+                return
         self.data = {k: [] for k in self.selected_vars}
         self.data["t"] = []
         self.data["MotorRunning"] = []  # 1 when spinning, 0 after stop command

--- a/README.md
+++ b/README.md
@@ -56,6 +56,9 @@ Detailed documentation is available at https://x2cscope.github.io/pyx2cscope/
    - Scale (RPM/count)
    - Logging time (seconds)
    - Sample interval (ms)
+     - Each enabled variable adds roughly **3&nbsp;ms** of overhead. When
+       `ENFORCE_SAMPLE_LIMIT` is enabled in the code, the GUI prevents
+       choosing an interval shorter than `3 × number_of_selected_variables`.
 3. Click **START** to capture data. Press **STOP** to end the capture early.
 4. Use the buttons to plot currents, plot speed, or save the captured data.
 


### PR DESCRIPTION
## Summary
- document per-variable capture delay and configurable check
- display ~3 ms overhead note in the GUI
- prevent selecting sample intervals shorter than 3 ms per variable

## Testing
- `python -m py_compile MotorLogger.py`

------
https://chatgpt.com/codex/tasks/task_e_6863d00402a0832394b11f860b24addb