### PR TITLE
Add sample interval helper and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,11 @@ Detailed documentation is available at https://x2cscope.github.io/pyx2cscope/
    - Target speed (RPM)
    - Scale (RPM/count)
    - Logging time (seconds)
-   - Sample interval (ms)
+    - Sample interval (ms)
+      - Each enabled variable adds roughly **3&nbsp;ms** of overhead. When
+        `ENFORCE_SAMPLE_LIMIT` is enabled (see :func:`min_allowed_interval` in
+        the code), the GUI prevents choosing an interval shorter than
+        `3 × number_of_selected_variables`.
 3. Click **START** to capture data. Press **STOP** to end the capture early.
 4. Use the buttons to plot currents, plot speed, or save the captured data.
 

--- a/tests/test_sample_interval.py
+++ b/tests/test_sample_interval.py
@@ -1,0 +1,34 @@
+import importlib
+import os
+import sys
+import types
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+# Provide a dummy serial module so MotorLogger can be imported without pyserial
+dummy_serial = types.ModuleType("serial")
+dummy_tools = types.ModuleType("serial.tools")
+dummy_tools.list_ports = types.ModuleType("serial.tools.list_ports")
+dummy_tools.list_ports.comports = lambda: []
+sys.modules.setdefault("serial", dummy_serial)
+sys.modules.setdefault("serial.tools", dummy_tools)
+sys.modules.setdefault("serial.tools.list_ports", dummy_tools.list_ports)
+
+# Stub pyx2cscope module expected by MotorLogger when USE_SCOPE is True
+dummy_scope_mod = types.ModuleType("pyx2cscope.x2cscope")
+dummy_scope_mod.X2CScope = object
+sys.modules.setdefault("pyx2cscope.x2cscope", dummy_scope_mod)
+
+import MotorLogger as ml
+ml.USE_SCOPE = False
+
+
+def test_min_interval_default(monkeypatch):
+    monkeypatch.setattr(ml, 'ENFORCE_SAMPLE_LIMIT', True)
+    assert ml.min_allowed_interval(1) == ml.MIN_DELAY_PER_VAR_MS
+    assert ml.min_allowed_interval(3) == 3 * ml.MIN_DELAY_PER_VAR_MS
+
+
+def test_min_interval_disabled(monkeypatch):
+    monkeypatch.setattr(ml, 'ENFORCE_SAMPLE_LIMIT', False)
+    assert ml.min_allowed_interval(5) == 0.0


### PR DESCRIPTION
## Summary
- add `min_allowed_interval` helper for enforcing per-variable overhead
- show the computed limit during capture start
- document helper in README
- add tests covering min interval logic

## Testing
- `python -m py_compile MotorLogger.py tests/test_sample_interval.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6863d00402a0832394b11f860b24addb