### PR TITLE
Fix messagebox errors when GUI is closing

### DIFF
--- a/MotorLogger.py
+++ b/MotorLogger.py
@@ -481,7 +481,14 @@ class MotorLoggerGUI:
                 if pd is None: raise RuntimeError("pandas not installed")
                 pd.DataFrame(self.data).to_excel(fn, index=False)
         except Exception as e:
-            messagebox.showerror("Save", str(e)); return
+            try:
+                if self.root.winfo_exists():
+                    messagebox.showerror("Save", str(e))
+                else:
+                    print(f"Save error: {e}")
+            except Exception:
+                print(f"Save error: {e}")
+            return
         messagebox.showinfo("Saved", fn)
 
     # ── Cleanup ──────────────────────────────────────────────────────────
@@ -497,7 +504,11 @@ class MotorLoggerGUI:
                 self._cap_thread.join(timeout=2)
             self.scope.disconnect()
         finally:
-            if self.root.winfo_exists():
+            try:
+                exists = self.root.winfo_exists()
+            except Exception:
+                exists = False
+            if exists:
                 try:
                     self.root.destroy()
                 except tk.TclError:


### PR DESCRIPTION
## Summary
- avoid calling `messagebox` when the window has been destroyed
- guard `winfo_exists` in `_on_close`

## Testing
- `python -m py_compile MotorLogger.py`

------
https://chatgpt.com/codex/tasks/task_e_6863d3f3118c8323869cfb542d48caff