### PR TITLE
Add sample rate help information

### DIFF
--- a/MotorLogger.py
+++ b/MotorLogger.py
@@ -166,6 +166,7 @@ class MotorLoggerGUI:
         self.dur_entry    = _row("Log time (s):",     "5",    2)
         self.sample_entry = _row("Sample every (ms):", str(self.DEFAULT_DT), 3)
         ttk.Label(parms, text="≈3 ms per enabled variable").grid(row=3, column=2, sticky="w")
+        ttk.Button(parms, text="?", width=2, command=self._show_sample_info).grid(row=3, column=3, padx=(2,0))
 
         # Buttons
         btn = ttk.Frame(main); btn.pack(pady=(6, 2))
@@ -234,6 +235,17 @@ class MotorLoggerGUI:
         else:
             txt = "Re-enable mS guard"
         self.guard_btn.config(text=txt)
+
+    def _show_sample_info(self):
+        """Explain sample interval limitations."""
+        messagebox.showinfo(
+            "Sample rate limits",
+            "Each enabled variable requires roughly 2.5 ms when using the\n"
+            "current polling implementation. The logger enforces about 3 ms\n"
+            "per variable to provide some margin. You can achieve faster\n"
+            "rates by optimizing the code, using lower level access calls,\n"
+            "or increasing the UART baud rate.",
+        )
 
     # ── Connection handling ───────────────────────────────────────────────
     def _toggle_conn(self): self._disconnect() if self.connected else self._connect()

--- a/README.md
+++ b/README.md
@@ -57,10 +57,13 @@ Detailed documentation is available at https://x2cscope.github.io/pyx2cscope/
    - Scale (RPM/count)
    - Logging time (seconds)
    - Sample interval (ms)
-    - Each enabled variable adds roughly **3&nbsp;ms** of overhead. The GUI
-      enforces a minimum interval of `3 × number_of_selected_variables`.
-      Use the experimental button to bypass this guard and try shorter
-      sampling periods.
+    - Each enabled variable adds roughly **3&nbsp;ms** of overhead. The
+      adjacent **?** button explains this comes from a polling approach that
+      limits each variable to about **2.5&nbsp;ms**. You can reduce the delay by
+      improving the capture code, using lower level calls, or increasing the
+      UART baud rate. The GUI enforces a minimum interval of
+      `3 × number_of_selected_variables`. Use the experimental button to bypass
+      this guard and try shorter sampling periods.
 3. Click **START** to capture data. Press **STOP** to end the capture early.
 4. Use the buttons to plot currents, plot speed, or save the captured data.
 


### PR DESCRIPTION
## Summary
- add help button describing sample rate limitations
- document recommended improvements in README

## Testing
- `python -m py_compile MotorLogger.py`

------
https://chatgpt.com/codex/tasks/task_e_68642d4008008323b0dd4e3b2d6b07dc