### PR TITLE
Fix scope clear helper for latest pyX2Cscope

### DIFF
--- a/MotorLogger.py
+++ b/MotorLogger.py
@@ -110,7 +110,13 @@ class _ScopeWrapper:
         """Configure scope channels and sampling interval."""
         if not USE_SCOPE or self._scope is None:
             return
-        self._scope.clear_scope_channels()
+        # pyX2Cscope renamed this helper in newer releases
+        if hasattr(self._scope, "clear_scope_channels"):
+            self._scope.clear_scope_channels()
+        elif hasattr(self._scope, "clear_all_scope_channel"):
+            self._scope.clear_all_scope_channel()
+        elif hasattr(self._scope, "clear_all_scope_channels"):
+            self._scope.clear_all_scope_channels()
         self._chan_map = {}
         for idx, var in enumerate(vars):
             ch = self._scope.add_scope_channel(var)


### PR DESCRIPTION
## Summary
- handle renamed `clear_scope_channels` method in newer pyX2Cscope

## Testing
- `python -m py_compile MotorLogger.py`


------
https://chatgpt.com/codex/tasks/task_e_68643d987acc8323bf3968bae28f735a