### PR TITLE
Add calibration values window

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,10 @@ Set `USE_SCOPE = False` to run the GUI without hardware.
 ## Resolver to Encoder Test App
 
 The repository also includes **ResolverEncoderApp.py**, a simplified GUI for logging resolver variables. It derives from the Motor Logger code and can be used to verify resolver functionality or capture data for calibration. The tool connects via `pyX2Cscope`, logs the raw and converted angles, and provides a one-click calibration request. Logged data can be saved as CSV for further analysis.
+The GUI now also includes a *View Cal Values* button that opens a small window
+listing the calibration variables read from the target so you can reprogram the
+MCU with the correct values.
+The window lists global variables like `resolver.offset` and `resolver.status` from the MCU firmware.
 
 Run it with:
 ```bash


### PR DESCRIPTION
## Summary
- add `CAL_VARS` mapping to specify calibration-related variables
- add a `View Cal Values` button in the resolver encoder GUI
- fetch and display calibration values from the target
- document the calibration variable list in the README

## Testing
- `python -m py_compile ResolverEncoderApp.py MotorLogger.py`


------
https://chatgpt.com/codex/tasks/task_e_6889cacb1940832396a3bbf03c84c7f9