### PR TITLE
Handle actual X2Cscope sample interval when validating data

### DIFF
--- a/NewVersion.py
+++ b/NewVersion.py
@@ -518,9 +518,9 @@ class MotorLoggerGUI:
                 )
             else:
                 self.scope_dt = self.ts
-            # Expected sample count based on the user-requested interval
-            # (scope_dt may differ slightly due to hardware quantisation)
-            self.expected_samples = int(round(target_total / self.ts))
+            # Expected sample count using the actual scope interval
+            # (scope_dt may differ slightly from the user request)
+            self.expected_samples = int(round(target_total / self.scope_dt))
             if abs(self.scope_dt - self.ts) > (self.ts * 0.05):
                 self.scope_issue = (
                     f"Sample time differs: requested {self.ts*1e3:.3f} ms, "

--- a/README.md
+++ b/README.md
@@ -69,6 +69,16 @@ Detailed documentation is available at https://x2cscope.github.io/pyx2cscope/
 3. Click **START** to capture data. Press **STOP** to end the capture early.
 4. Use the buttons to plot currents, plot speed, or save the captured data.
 
+### Sample timing
+
+The logger configures X2Cscope's sampling interval using a prescaler based on
+the MCU's base time.  Some devices use a base time other than the default
+50 µs, which means the **actual** sample interval can differ from the
+user‑requested value.  The tool now checks the real interval reported by
+X2Cscope and computes the expected sample count from this value so the
+validation step is accurate.  If you have a data‑model dump that lists the
+timer base, you can set `scope.base_us_override` accordingly for precise timing.
+
 ## How to Determine RPM/Count Scaling
 
 Refer to the MotorBench report located at:


### PR DESCRIPTION
## Summary
- Compute expected sample count from the sampling interval reported by X2Cscope
- Document how the hardware base time can change the effective sample period

## Testing
- `python -m py_compile NewVersion.py`

------
https://chatgpt.com/codex/tasks/task_e_68b475cd96b083238e3372ad215ce8c3