### PR TITLE
Align watchscope timing across apps

### DIFF
--- a/MotorLogger2.py
+++ b/MotorLogger2.py
@@ -459,7 +459,7 @@ class MotorLoggerGUI:
                             self.data[key].extend(v * scale for v in vals)
 
 
-                time.sleep(self.ts / 10)
+                time.sleep(0.25)
         finally:
             try:
                 if self.root.winfo_exists():

--- a/NewVersion.py
+++ b/NewVersion.py
@@ -594,7 +594,7 @@ class MotorLoggerGUI:
 
                         sample_idx += n
 
-                time.sleep(self.ts / 10)
+                time.sleep(0.25)
 
             self.actual_samples = sample_idx
 

--- a/ResolverEncoderApp.py
+++ b/ResolverEncoderApp.py
@@ -73,7 +73,11 @@ class _ScopeWrapper:
             self._scope.clear_scope_channels()
         for var in vars:
             self._scope.add_scope_channel(var)
-        self._scope.set_sample_time(sample_ms)
+        # Convert desired interval (ms) to prescaler using 50 µs base period
+        base_us = 50.0
+        desired_us = max(int(sample_ms), 1) * 1000
+        prescaler = max(int(round(desired_us / base_us)) - 1, 0)
+        self._scope.set_sample_time(prescaler)
         self._scope.request_scope_data()
 
     def scope_ready(self) -> bool:
@@ -82,7 +86,7 @@ class _ScopeWrapper:
     def get_scope_data(self):
         if not USE_SCOPE or not self._scope:
             return {}
-        return self._scope.get_scope_channel_data(valid_data=False)
+        return self._scope.get_scope_channel_data(valid_data=True)
 
     def request_scope_data(self):
         if USE_SCOPE and self._scope:
@@ -334,7 +338,7 @@ class ResolverEncoderGUI:
                             if key is None:
                                 continue
                             self.data[key].extend(vals)
-                time.sleep(self.ts / 10)
+                time.sleep(0.25)
         finally:
             try:
                 if self.root.winfo_exists():

--- a/motorTuner.py
+++ b/motorTuner.py
@@ -346,11 +346,11 @@ if __name__ == '__main__':
 
     # Storing the data and plotting it
     x2c_scope.request_scope_data()
-    time.sleep(0.1)
+    time.sleep(0.25)
     data_storage = {}
     try:
         while not x2c_scope.is_scope_data_ready():
-            time.sleep(0.5)
+            time.sleep(0.25)
     except KeyboardInterrupt:
         pass
 
@@ -425,11 +425,11 @@ if __name__ == '__main__':
 
             # Storing the data and plotting
             x2c_scope.request_scope_data()
-            time.sleep(0.1)
+            time.sleep(0.25)
             data_storage = {} 
             try:
                 while not x2c_scope.is_scope_data_ready():
-                    time.sleep(0.5)
+                    time.sleep(0.25)
             except KeyboardInterrupt:
                 pass
 

--- a/motor_logger_gui.py
+++ b/motor_logger_gui.py
@@ -187,9 +187,9 @@ class RealScopeBackend(ScopeBackend):
                 self.scope.add_scope_channel(var)
                 self.scope.set_sample_time(1)
                 self.scope.request_scope_data()
-                time.sleep(0.05)
+                time.sleep(0.25)
                 while not self.scope.is_scope_data_ready():
-                    time.sleep(0.01)
+                    time.sleep(0.25)
                 data = self.scope.get_scope_channel_data(valid_data=True)
                 samples = len(next(iter(data.values())))
                 bytes_per_sample = self.channel_widths[0]
@@ -547,14 +547,14 @@ class MotorLoggerGUI(QWidget):
         motor_on = self.motor_on_spin.value()
         if motor_on > 0:
             QTimer.singleShot(int(motor_on*1000), lambda: self.backend.write_var("motor.enable", 0))
-        QTimer.singleShot(int(duration*1000)+100, self.poll_ready)
+        QTimer.singleShot(0, self.poll_ready)
         self.status.showMessage("Capture in progress...")
 
     def poll_ready(self) -> None:
         if self.backend.is_scope_ready():
             self.finish_capture()
         else:
-            QTimer.singleShot(100, self.poll_ready)
+            QTimer.singleShot(250, self.poll_ready)
 
     def finish_capture(self) -> None:
         data = self.backend.get_data()


### PR DESCRIPTION
## Summary
- Convert sample intervals to prescalers before setting scope sample time and request only valid watchscope frames
- Poll watchscope readiness every 250 ms across command-line and GUI tools for consistent timing

## Testing
- `python -m py_compile MotorLogger.py MotorLogger2.py NewVersion.py ResolverEncoderApp.py motorTuner.py motor_logger_gui.py generic-gui.py`


------
https://chatgpt.com/codex/tasks/task_e_68b4acaefe6083239979c3050d9df524