### PR TITLE
Add Tkinter GUI for MotorLogger4

### DIFF
--- a/MotorLogger4.py
+++ b/MotorLogger4.py
@@ -89,9 +89,12 @@ def parse_args() -> argparse.Namespace:
 
 # ---------------------------------------------------------------------------
 
-def main() -> None:
-    args = parse_args()
-    counts = args.speed / args.scale
+def run_motor_logger(elf: str, port: str, baud: int, speed: float, scale: float) -> None:
+    """Run the logger with provided settings.
+
+    This is the core routine used by both the CLI and the Tkinter GUI.
+    """
+    counts = speed / scale
 
     scope: Optional[X2CScope] = None
     run_sent = False
@@ -99,9 +102,9 @@ def main() -> None:
     var_handles: Dict[str, Optional[int]] = {}
 
     try:
-        scope = X2CScope(port=args.port, baudrate=args.baud, elf_file=args.elf)
+        scope = X2CScope(port=port, baudrate=baud, elf_file=elf)
         try:  # Older versions require explicit import
-            scope.import_variables(args.elf)
+            scope.import_variables(elf)
         except Exception:
             pass
 
@@ -245,6 +248,11 @@ def main() -> None:
                     except Exception:
                         pass
             scope.close()
+
+
+def main() -> None:
+    args = parse_args()
+    run_motor_logger(args.elf, args.port, args.baud, args.speed, args.scale)
 
 
 if __name__ == "__main__":

--- a/MotorLogger4_gui.py
+++ b/MotorLogger4_gui.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+"""Simple Tkinter GUI wrapper for MotorLogger4."""
+
+from __future__ import annotations
+
+import io
+import threading
+import tkinter as tk
+from tkinter import filedialog, messagebox, ttk
+from contextlib import redirect_stdout, redirect_stderr
+
+from MotorLogger4 import list_ports, run_motor_logger
+
+
+class MotorLoggerApp(tk.Tk):
+    """Tkinter front end for :mod:`MotorLogger4`."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.title("MotorLogger4 GUI")
+        self._build_widgets()
+
+    # ------------------------------------------------------------------
+    def _build_widgets(self) -> None:
+        row = 0
+        ttk.Label(self, text="ELF Path:").grid(row=row, column=0, sticky="e", padx=5, pady=2)
+        self.elf_var = tk.StringVar()
+        ttk.Entry(self, textvariable=self.elf_var, width=40).grid(row=row, column=1, padx=5, pady=2)
+        ttk.Button(self, text="Browse", command=self._browse_elf).grid(row=row, column=2, padx=5, pady=2)
+
+        row += 1
+        ttk.Label(self, text="Port:").grid(row=row, column=0, sticky="e", padx=5, pady=2)
+        self.port_var = tk.StringVar()
+        self.port_combo = ttk.Combobox(self, textvariable=self.port_var, values=list_ports())
+        self.port_combo.grid(row=row, column=1, padx=5, pady=2, sticky="we")
+        ttk.Button(self, text="Refresh", command=self._refresh_ports).grid(row=row, column=2, padx=5, pady=2)
+        self._refresh_ports()
+
+        row += 1
+        ttk.Label(self, text="Baud:").grid(row=row, column=0, sticky="e", padx=5, pady=2)
+        self.baud_var = tk.IntVar(value=115200)
+        ttk.Combobox(
+            self,
+            textvariable=self.baud_var,
+            values=[115200, 230400, 460800, 921600],
+            width=10,
+        ).grid(row=row, column=1, padx=5, pady=2, sticky="w")
+
+        row += 1
+        ttk.Label(self, text="Speed (RPM):").grid(row=row, column=0, sticky="e", padx=5, pady=2)
+        self.speed_var = tk.DoubleVar(value=0.0)
+        ttk.Entry(self, textvariable=self.speed_var, width=15).grid(row=row, column=1, padx=5, pady=2, sticky="w")
+
+        row += 1
+        ttk.Label(self, text="Scale (RPM/count):").grid(row=row, column=0, sticky="e", padx=5, pady=2)
+        self.scale_var = tk.DoubleVar(value=1.0)
+        ttk.Entry(self, textvariable=self.scale_var, width=15).grid(row=row, column=1, padx=5, pady=2, sticky="w")
+
+        row += 1
+        self.run_btn = ttk.Button(self, text="Run", command=self._start_run)
+        self.run_btn.grid(row=row, column=0, columnspan=3, pady=5)
+
+        row += 1
+        self.output = tk.Text(self, width=60, height=15)
+        self.output.grid(row=row, column=0, columnspan=3, padx=5, pady=5)
+
+    # ------------------------------------------------------------------
+    def _browse_elf(self) -> None:
+        path = filedialog.askopenfilename(filetypes=[("ELF files", "*.elf"), ("All files", "*.*")])
+        if path:
+            self.elf_var.set(path)
+
+    def _refresh_ports(self) -> None:
+        ports = list_ports()
+        self.port_combo["values"] = ports
+        if ports and not self.port_var.get():
+            self.port_var.set(ports[0])
+
+    # ------------------------------------------------------------------
+    def _start_run(self) -> None:
+        elf = self.elf_var.get().strip()
+        port = self.port_var.get().strip()
+        baud = int(self.baud_var.get())
+        speed = float(self.speed_var.get())
+        scale = float(self.scale_var.get())
+        if not elf or not port:
+            messagebox.showerror("Error", "ELF path and port are required")
+            return
+        self.run_btn.config(state=tk.DISABLED)
+        self.output.delete("1.0", tk.END)
+
+        def worker() -> None:
+            buf = io.StringIO()
+            try:
+                with redirect_stdout(buf), redirect_stderr(buf):
+                    run_motor_logger(elf, port, baud, speed, scale)
+            except Exception as exc:  # pragma: no cover - hardware dependent
+                buf.write(f"Error: {exc}\n")
+            finally:
+                text = buf.getvalue()
+                self.after(0, self._finish_run, text)
+
+        threading.Thread(target=worker, daemon=True).start()
+
+    def _finish_run(self, text: str) -> None:
+        self.output.insert(tk.END, text)
+        self.run_btn.config(state=tk.NORMAL)
+
+
+if __name__ == "__main__":
+    app = MotorLoggerApp()
+    app.mainloop()


### PR DESCRIPTION
## Summary
- Refactor MotorLogger4 logic into reusable `run_motor_logger` function
- Introduce simple Tkinter GUI to select settings and run MotorLogger4

## Testing
- `python -m py_compile MotorLogger4.py MotorLogger4_gui.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b4cb1292fc8323b0a31dabec14ae60